### PR TITLE
Fill ETS table for local development

### DIFF
--- a/lib/preview/application.ex
+++ b/lib/preview/application.ex
@@ -6,8 +6,6 @@ defmodule Preview.Application do
   use Application
 
   def start(_type, _args) do
-    setup_tmp_dir()
-
     children = [
       PreviewWeb.Telemetry,
       {Phoenix.PubSub, name: Preview.PubSub},
@@ -21,11 +19,7 @@ defmodule Preview.Application do
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Preview.Supervisor]
-    sup = Supervisor.start_link(children, opts)
-
-    setup_local_ets()
-
-    sup
+    Supervisor.start_link(children, opts)
   end
 
   # Tell Phoenix to update the endpoint configuration
@@ -40,14 +34,6 @@ defmodule Preview.Application do
       File.mkdir_p!(dir)
       Application.put_env(:preview, :tmp_dir, Path.expand(dir))
     end
-  end
-
-  if Application.get_env(:preview, :package_updater_impl) == Preview.Package.LocalUpdater do
-    defp setup_local_ets do
-      Preview.Package.Store.fill([{"decimal", ["2.0.0"]}, {"ecto", ["0.2.0"]}])
-    end
-  else
-    defp setup_local_ets, do: nil
   end
 
   defp finch_pools() do

--- a/lib/preview/application.ex
+++ b/lib/preview/application.ex
@@ -21,7 +21,11 @@ defmodule Preview.Application do
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Preview.Supervisor]
-    Supervisor.start_link(children, opts)
+    sup = Supervisor.start_link(children, opts)
+
+    setup_local_ets()
+
+    sup
   end
 
   # Tell Phoenix to update the endpoint configuration
@@ -36,6 +40,14 @@ defmodule Preview.Application do
       File.mkdir_p!(dir)
       Application.put_env(:preview, :tmp_dir, Path.expand(dir))
     end
+  end
+
+  if Application.get_env(:preview, :package_updater_impl) == Preview.Package.LocalUpdater do
+    defp setup_local_ets do
+      Preview.Package.Store.fill([{"decimal", ["2.0.0"]}, {"ecto", ["0.2.0"]}])
+    end
+  else
+    defp setup_local_ets, do: nil
   end
 
   defp finch_pools() do

--- a/lib/preview/application.ex
+++ b/lib/preview/application.ex
@@ -6,6 +6,8 @@ defmodule Preview.Application do
   use Application
 
   def start(_type, _args) do
+    setup_tmp_dir()
+
     children = [
       PreviewWeb.Telemetry,
       {Phoenix.PubSub, name: Preview.PubSub},

--- a/lib/preview/package/local_updater.ex
+++ b/lib/preview/package/local_updater.ex
@@ -8,6 +8,7 @@ defmodule Preview.Package.LocalUpdater do
 
   def init(_opts) do
     Logger.debug("Skipping version updater")
+    Preview.Package.Store.fill([{"decimal", ["2.0.0"]}, {"ecto", ["0.2.0"]}])
     {:ok, []}
   end
 end


### PR DESCRIPTION
Close #23

That can be improved but I'd like to propose a way to fill the local ETS table in development.

<img width="525" alt="Screen Shot 2021-01-25 at 5 51 18 PM" src="https://user-images.githubusercontent.com/36407/105776090-f3049000-5f35-11eb-8807-8c57a1d7f88c.png">
