### PR TITLE
Remove conflicting behaviour

### DIFF
--- a/lib/preview/storage/gcs.ex
+++ b/lib/preview/storage/gcs.ex
@@ -6,6 +6,7 @@ defmodule Preview.Storage.GCS do
 
   import SweetXml, only: [sigil_x: 2]
 
+  @impl true
   def get(bucket, key, _opts) do
     url = url(bucket, key)
 
@@ -15,10 +16,12 @@ defmodule Preview.Storage.GCS do
     end
   end
 
+  @impl true
   def list(bucket, prefix) do
     list_stream(bucket, prefix)
   end
 
+  @impl true
   def put(bucket, key, body, _opts) do
     url = url(bucket, key)
 
@@ -28,6 +31,7 @@ defmodule Preview.Storage.GCS do
     :ok
   end
 
+  @impl true
   def delete_many(bucket, keys) do
     keys
     |> Task.async_stream(

--- a/lib/preview/storage/local.ex
+++ b/lib/preview/storage/local.ex
@@ -1,7 +1,7 @@
 defmodule Preview.Storage.Local do
-  @behaviour Preview.Storage.Repo
   @behaviour Preview.Storage.Preview
 
+  @impl true
   def list(bucket, prefix) do
     path(bucket, prefix <> "**")
     |> Path.wildcard(match_dot: true)
@@ -9,6 +9,7 @@ defmodule Preview.Storage.Local do
     |> Enum.map(&Path.relative_to(&1, path(bucket)))
   end
 
+  @impl true
   def get(bucket, key, _opts) do
     case File.read(path(bucket, key)) do
       {:ok, content} -> content
@@ -16,12 +17,14 @@ defmodule Preview.Storage.Local do
     end
   end
 
+  @impl true
   def put(bucket, key, body, _opts) do
     path = path(bucket, key)
     File.mkdir_p!(Path.dirname(path))
     File.write!(path, body)
   end
 
+  @impl true
   def delete_many(bucket, keys) do
     Enum.each(keys, &File.rm_rf!(path(bucket, &1)))
   end

--- a/lib/preview/storage/s3.ex
+++ b/lib/preview/storage/s3.ex
@@ -1,6 +1,7 @@
 defmodule Preview.Storage.S3 do
   @behaviour Preview.Storage.Repo
 
+  @impl true
   def get(bucket, key, opts) do
     ExAws.S3.get_object(bucket, key, opts)
     |> ExAws.request()


### PR DESCRIPTION
Having both:

    defmodule Preview.Storage.Local do
      @behaviour Preview.Storage.Repo
      @behaviour Preview.Storage.Preview

Caused a warning:

    warning: conflicting behaviours found. function get/3 is required by Preview.Storage.Repo and Preview.Storage.Preview (in module Preview.Storage.Local)
      lib/preview/storage/local.ex:1: Preview.Storage.Local (module)

I decided to only keep `@behaviour Preview.Storage.Preview` as Repo
behaviour is a subset of that.
