### PR TITLE
Don't encode filename in url

### DIFF
--- a/lib/preview_web/live/preview_live.ex
+++ b/lib/preview_web/live/preview_live.ex
@@ -5,7 +5,11 @@ defmodule PreviewWeb.PreviewLive do
   def mount(params, _session, socket) do
     if all_files = Preview.Bucket.get_file_list(params["package"], params["version"]) do
       filename =
-        if params["filename"], do: URI.decode(params["filename"]), else: default_file(all_files)
+        if params["filename"] do
+          Path.join(params["filename"])
+        else
+          default_file(all_files)
+        end
 
       file_contents = file_contents_or_default(params["package"], params["version"], filename)
 
@@ -58,7 +62,7 @@ defmodule PreviewWeb.PreviewLive do
 
     {:noreply,
      push_patch(socket,
-       to: Routes.preview_path(socket, :index, package, version, filename),
+       to: Routes.preview_path(socket, :index, package, version) <> "/show/#{filename}",
        replace: true
      )}
   end

--- a/lib/preview_web/router.ex
+++ b/lib/preview_web/router.ex
@@ -20,8 +20,8 @@ defmodule PreviewWeb.Router do
     pipe_through :browser
 
     live "/", SearchLive, :index
-    live "/preview/:package/:version/:filename", PreviewLive, :index
     live "/preview/:package/:version", PreviewLive, :index
+    live "/preview/:package/:version/show/*filename", PreviewLive, :index
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
Closes #16

~given we're changing the URL pattern, we need to coordinate this change with hexpm.~

(Nevermind, we don't link to particular files from hexpm)