### PR TITLE
Move line highlighting into more javascript, less liveview

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -24,8 +24,24 @@ Hooks.updateHash = {
             let loc = window.location;
             let url = loc.protocol + '//' + loc.host + loc.pathname + '#L' + this.el.dataset.lineNumber;
             history.pushState(history.state, document.title, url);
+            update_hash()
             e.preventDefault();
-        })
+        });
+    }
+}
+
+window.onhashchange = function () {
+    update_hash()
+}
+
+function update_hash() {
+    let hash = location.hash
+    // clear existing highlighted lines
+    Array.from(document.getElementsByClassName("highlighted")).forEach(function (n, i) { n.classList.remove('highlighted') })
+
+    if (hash.startsWith("#L")) {
+        let id = hash.slice(1)
+        document.getElementById(id).classList.add("highlighted");
     }
 }
 
@@ -34,7 +50,7 @@ let liveSocket = new LiveSocket("/live", Socket, { params: { _csrf_token: csrfTo
 
 // Show progress bar on live navigation and form submits
 window.addEventListener("phx:page-loading-start", info => NProgress.start())
-window.addEventListener("phx:page-loading-stop", info => NProgress.done())
+window.addEventListener("phx:page-loading-stop", info => { NProgress.done(); update_hash(); })
 
 // connect if there are any LiveViews on the page
 liveSocket.connect()

--- a/lib/preview_web/live/preview_live.html.leex
+++ b/lib/preview_web/live/preview_live.html.leex
@@ -17,8 +17,7 @@
         <% lines = String.split(@file_contents, "\n") |> length() %>
         <ul id="left_gutter">
           <%= for ln <- 1..lines do %>
-            <% class = if @selected_line == ln, do: "highlighted", else: "" %>
-            <li class="<%= class %>" phx-hook="updateHash" phx-click="highlight_line" phx-value-line-number="<%= ln %>" id="L<%= ln %>" data-line-number="<%= ln %>"></li>
+            <li phx-hook="updateHash" id="L<%= ln %>" data-line-number="<%= ln %>"></li>
           <% end %>
         </ul>
         <%= raw print_file_contents(@file_contents, @filename) %>


### PR DESCRIPTION
- looks for anchor tag after page is done loading
- listens to hashchange so back button works
I've tested this in Chrome and Firefox on Ubuntu 20.04

I want to test it on mac before merging

Closes: #44 