### PR TITLE
Fix flash alert rendering when not needed

### DIFF
--- a/lib/preview_web/templates/layout/live.html.heex
+++ b/lib/preview_web/templates/layout/live.html.heex
@@ -1,7 +1,19 @@
 <main role="main" class="container">
-  <p class="alert alert-info" role="alert" phx-click="lv:clear-flash" phx-value-key="info"><%= live_flash(@flash, :info) %></p>
+  <p
+    class="alert alert-info"
+    role="alert"
+    phx-click="lv:clear-flash"
+    phx-value-key="info"
+    phx-no-format
+  ><%= live_flash(@flash, :info) %></p>
 
-  <p class="alert alert-danger" role="alert" phx-click="lv:clear-flash" phx-value-key="error"><%= live_flash(@flash, :error) %></p>
+  <p
+    class="alert alert-danger"
+    role="alert"
+    phx-click="lv:clear-flash"
+    phx-value-key="error"
+    phx-no-format
+  ><%= live_flash(@flash, :error) %></p>
 
   <%= @inner_content %>
 </main>

--- a/lib/preview_web/templates/layout/live.html.heex
+++ b/lib/preview_web/templates/layout/live.html.heex
@@ -1,11 +1,7 @@
 <main role="main" class="container">
-  <p class="alert alert-info" role="alert" phx-click="lv:clear-flash" phx-value-key="info">
-    <%= live_flash(@flash, :info) %>
-  </p>
+  <p class="alert alert-info" role="alert" phx-click="lv:clear-flash" phx-value-key="info"><%= live_flash(@flash, :info) %></p>
 
-  <p class="alert alert-danger" role="alert" phx-click="lv:clear-flash" phx-value-key="error">
-    <%= live_flash(@flash, :error) %>
-  </p>
+  <p class="alert alert-danger" role="alert" phx-click="lv:clear-flash" phx-value-key="error"><%= live_flash(@flash, :error) %></p>
 
   <%= @inner_content %>
 </main>


### PR DESCRIPTION
There's a CSS rule to not render the alert when the element is empty. The spaces in the template caused it to render. I removed them to fix the issue.