### PR TITLE
Fix crash when package has empty file list

### DIFF
--- a/lib/preview_web/live/preview_live.ex
+++ b/lib/preview_web/live/preview_live.ex
@@ -21,7 +21,7 @@ defmodule PreviewWeb.PreviewLive do
     package = params["package"]
     version = params["version"] || Preview.Bucket.get_latest_version(package)
 
-    if all_files = Preview.Bucket.get_file_list(package, version) do
+    with [_ | _] = all_files <- Preview.Bucket.get_file_list(package, version) do
       filename =
         case params["filename"] do
           [_ | _] = parts -> Path.join(parts)
@@ -55,7 +55,7 @@ defmodule PreviewWeb.PreviewLive do
          canonical: canonical_url(package, filename)
        )}
     else
-      raise Exception, plug_status: 404
+      _ -> raise Exception, plug_status: 404
     end
   end
 

--- a/test/preview_web/live/preview_live_test.exs
+++ b/test/preview_web/live/preview_live_test.exs
@@ -51,6 +51,22 @@ defmodule PreviewWeb.PreviewLiveTest do
 
       assert render(view) =~ "<h2>README.md</h2>"
     end
+
+    test "returns 404 when file list is empty", %{conn: conn} do
+      package = Fake.random(:package)
+      version = "0.1.0"
+      file_list = Jason.encode!([])
+
+      Storage.put(@preview_bucket, "file_lists/#{package}-#{version}.json", file_list)
+      Storage.put(@preview_bucket, "latest_versions/#{package}", version)
+
+      exception =
+        assert_raise PreviewWeb.PreviewLive.Exception, fn ->
+          live(conn, "/preview/#{package}/#{version}")
+        end
+
+      assert exception.plug_status == 404
+    end
   end
 
   describe "default_file/1" do


### PR DESCRIPTION
Return 404 instead of crashing with ArgumentError when get_file_list returns an empty list. The `if` guard only checked for nil, so an empty list reached hd/1 in default_file/1.