### PR TITLE
Remove invalid redirect options from hex adapter

### DIFF
--- a/lib/preview/hex/adapter.ex
+++ b/lib/preview/hex/adapter.ex
@@ -1,14 +1,12 @@
 defmodule Preview.Hex.Adapter do
   @behaviour :hex_http
 
-  @opts [follow_redirect: true, max_redirect: 5]
-
   @impl true
   def request(:get, uri, req_headers, _req_body, _config) do
     req_headers = prepare_headers(req_headers, nil)
 
     {:ok, status, resp_headers, resp_body} =
-      Preview.HTTP.retry("hex_adapter", uri, fn -> Preview.HTTP.get(uri, req_headers, @opts) end)
+      Preview.HTTP.retry("hex_adapter", uri, fn -> Preview.HTTP.get(uri, req_headers) end)
 
     # :hex_core expects headers to be a Map
     resp_headers = Map.new(resp_headers)
@@ -21,7 +19,7 @@ defmodule Preview.Hex.Adapter do
 
     {:ok, status, resp_headers, resp_body} =
       Preview.HTTP.retry("hex_adapter", uri, fn ->
-        Preview.HTTP.put(uri, req_headers, payload, @opts)
+        Preview.HTTP.put(uri, req_headers, payload)
       end)
 
     # :hex_core expects headers to be a Map


### PR DESCRIPTION
Finch 0.22.0 now validates request options strictly via `Keyword.validate!/2` and raises on unknown keys. The `follow_redirect: true` and `max_redirect: 5` options in `Preview.Hex.Adapter` were HTTPoison/Hackney-style options that Finch never supported — they were silently ignored before and now produce:

```
ArgumentError: unknown keys [:max_redirect, :follow_redirect] in [follow_redirect: true, max_redirect: 5],
the allowed keys are: [:pool_timeout, :receive_timeout, :request_timeout, :pool_strategy]
```

Finch does not follow redirects automatically, so removing these options is a no-op behaviorally.